### PR TITLE
Display split proportions in ExpenseCard

### DIFF
--- a/src/main/java/fairshare/ui/ExpenseCard.java
+++ b/src/main/java/fairshare/ui/ExpenseCard.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.stream.Collectors;
 
 import fairshare.model.expense.Expense;
+import fairshare.model.expense.Participant;
 import fairshare.ui.exceptions.UiException;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
@@ -53,20 +54,39 @@ public class ExpenseCard {
             throw new UiException("Failed to load " + FXML, e);
         }
 
+        int totalShares = expense.getTotalShares();
+
         indexLabel.setText(displayIndex + ". ");
         expenseNameLabel.setText(expense.getExpenseName());
         amountLabel.setText(String.format("$%.2f", expense.getAmount()));
         payerLabel.setText("Paid by: " + expense.getPayer().getName());
 
         String participants = expense.getParticipants().stream()
-                .map(p -> p.getPerson().getName())
+                .map(p -> formatParticipant(p, totalShares))
                 .collect(Collectors.joining(", "));
         participantsLabel.setText("Participants: " + participants);
 
         String tags = expense.getTags().stream()
                 .map(t -> t.getTagName())
                 .collect(Collectors.joining(", "));
-        tagsLabel.setText("Tags: " + tags);
+        tagsLabel.setText("Tags: " + (tags.isEmpty() ? "-" : tags));
+    }
+
+    /**
+     * Format a participant's name with their proportion as a fraction.
+     * For example, bob with 2 shares out of 3 total displays as "bob (2/3)".
+     *
+     * @param participant the participant to format; cannot be null.
+     * @param totalShares the total number of shares in the expense.
+     * @return a formatted string showing the participant's name and fraction.
+     */
+    private  String formatParticipant(Participant participant, int totalShares) {
+        return participant.getPerson().getName()
+                + "("
+                + participant.getShares()
+                + "/"
+                + totalShares
+                + ")";
     }
 
     /**


### PR DESCRIPTION
Display split proportions as fractions in ExpenseCard display. For example: "Participants: bob (2/3), mary (1/3)"